### PR TITLE
Update README to cover what happens after closing an RFC

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,9 @@ The DevTools RFC process aims to be lightweight and focused on conversations. Th
 
 The [DevTools RFC team][] will be ultimately responsible for accepting or rejecting a change proposal, but the discussion is open to everybody.
 
-The list of RFCs currently under discussion can be found at: [Active RFC List][].
+The list of RFCs currently under discussion can be found at: [Active RFCs][].
 
-Previously reviewed RFCs:
-- [Accepted RFCs][]
-- [Rejected RFCs][]
-
-## Creating a RFC
+## Creating RFCs
 
 * Create an issue with the "proposal" label
 * Get people's attention. Some options:
@@ -27,16 +23,31 @@ Each week the [DevTools RFC team][] will attempt to review some set of open RFC 
 
 The team will send an email a few days prior to the review meeting to [dev-developer-tools][] to announce which RFCs are likely to be reviewed, and encourage peers to comment if needed.
 
-## Accepting/Rejecting a RFC
+## Closing RFCs
 
-After a proposal has been discussed and the related issue is ready to be closed, the DevTools core team will label the issue either as `accepted` or `rejected`, and will add a comment that summarizes the decision.
+After a proposal has been discussed and consensus has been reached, the DevTools core team will label the issue either as `accepted` or `rejected`, and will add a comment that summarizes the decision.
 
-If an accepted RFC is actionable, it should have an owner who will represent the feature and its progress. This can be the RFC author, but it's not necessary.
+Accepted RFCs remain open until an item is created to track the implementation of the change. This item can be a bug in Bugzilla, an issue on another GitHub repository, etc…
+
+Once an action has been logged, the accepted RFC is closed and labeled `in-progress`. The DevTools core team will try to regularly check accepted RFCs still marked as `in-progress` to see if they can be unblocked or need to be discussed again.
+
+When the action is implemented, the `in-progress` label is removed and the RFC is considered as completed.
+
+## RFC lifecyle
+
+Checkout the issue lists below to see which RFCs are in each state:
+* [Active RFCs][]
+* [Rejected RFCs][]
+* [Accepted RFCs waiting for action][]
+* [Accepted RFCs in-progress][]
+* [Completed RFCs][]
 
 [DevTools RFC team]: https://github.com/orgs/devtools-html/teams/devtools-rfc
-[Active RFC List]: https://github.com/devtools-html/rfcs/issues?q=is%3Aopen+is%3Aissue+label%3Aproposal
-[Accepted RFCs]: https://github.com/devtools-html/rfcs/issues?q=is%3Aopen+is%3Aissue+label%3Aaccepted
-[Rejected RFCs]: https://github.com/devtools-html/rfcs/issues?q=is%3Aopen+is%3Aissue+label%3Arejected
+[Active RFCs]: https://github.com/devtools-html/rfcs/issues?q=is%3Aopen+is%3Aissue+label%3Aproposal
+[Rejected RFCs]: https://github.com/devtools-html/rfcs/issues?q=is%3Aclosed+is%3Aissue+label%3Arejected
+[Accepted RFCs waiting for action]: https://github.com/devtools-html/rfcs/issues?q=is%3Aopen+is%3Aissue+label%3Aaccepted
+[Accepted RFCs in-progress]: https://github.com/devtools-html/rfcs/issues?q=is%3Aclosed+is%3Aissue+label%3Ain-progress
+[Completed RFCs]: https://github.com/devtools-html/rfcs/issues?q=is%3Aclosed+is%3Aissue+-label%3Ain-progress+label%3Aaccepted
 [dev-developer-tools]: https://lists.mozilla.org/listinfo/dev-developer-tools
 [devtools-weekly-meetings]: https://docs.google.com/a/mozilla.com/document/d/1pUx9xq6L7bonSrDpyUNTQkQxTxAsULLu4kkHZLMEq6w/edit?usp=drive_web
 [Slack]: https://devtools-html-slack.herokuapp.com/


### PR DESCRIPTION
As discussed during last week's meeting, here is a slight update to the README covering how to handle RFCs that are already closed. It's not too specific, it mainly has links to relevant issue lists with the good filters (fyi, the links on the current README are incorrect)

On a sidenote, I initially had a first commit that was rewriting all the "a RFC" to "an RFC", because the former is just impossible to pronounce. It had a great commit message. But after rewriting a bit the titles of our chapters, all the "a rfc" are gone. You will never have the chance to see this commit, but it deserved to be mentioned. 